### PR TITLE
ci: skip pr-verifier for dependabot PRs

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -1,0 +1,21 @@
+name: pr-verifier
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  verify-pr:
+    name: verify PR contents
+    # Skip verification for dependabot PRs - they use different title conventions
+    if: github.actor != 'dependabot[bot]'
+    permissions:
+      checks: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verifier action
+      id: verifier
+      uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Skip PR title verification for dependabot PRs since they use different title conventions (deps:, ci:) than the expected emoji prefixes.